### PR TITLE
feature(bau): add TS restriction for return value of `bau.derive`

### DIFF
--- a/bau/bau.d.ts
+++ b/bau/bau.d.ts
@@ -2,6 +2,8 @@ export type State<T> = {
   val: T;
 };
 
+export type ReadonlyState<T> = ReadonlyState<State<T>>;
+
 export interface StateView<T> {
   readonly val: T;
 }
@@ -12,7 +14,7 @@ export type StatePrimitive = Primitive | object;
 
 export type StateValue = StatePrimitive | StatePrimitive[];
 
-export type Deps = State<StateValue>[];
+export type Deps = ReadonlyState<StateValue>[];
 
 export type PropValue = StatePrimitive | Function | null | undefined;
 
@@ -247,5 +249,5 @@ export default function Bau(input?: { window?: Window }): {
   tagsNS: (namespaceURI: string) => TagsBase;
   state: <T>(initVal: T) => State<T>;
   bind: (input: BindInput) => (...args: any) => HTMLElement;
-  derive: <T>(computed: () => T) => State<T>;
+  derive: <T>(computed: () => T) => ReadonlyState<T>;
 };

--- a/doc/BauDerive.md
+++ b/doc/BauDerive.md
@@ -20,7 +20,7 @@ console.log(myDerivedState.val); // true
 
 The _derivation_ function and the derived state _myDerivedState_ have some restrictions:
 
-1. Do not mutate _myDerivedState_:
+1. Do not mutate _myDerivedState_: (This is directly restricted in TypeScript)
 
 ```js
 myDerivedState.val = false; // DON'T DO


### PR DESCRIPTION
`bau.d.ts` is updated, and so is the doc. I've defined a new type of `ReadonlyState` instead of using `StateView` straight away, because I think it's two different stuff.

`bau.d.ts` is updated, and so is the doc. 