### PR TITLE
Update bau.d.ts to have automatic types for event listeners as props

### DIFF
--- a/bau/bau.d.ts
+++ b/bau/bau.d.ts
@@ -99,10 +99,7 @@ export type Props<TElement extends HTMLElement> = {
 };
 
 export type PropsHTMLElement<TElement extends HTMLElement> = {
-  readonly [key in keyof TElement]?:
-    | PropValue
-    | StateView<PropValue>
-    | BindAttributeFunc<TElement>;
+  readonly [key in keyof TElement as key extends `on${string}` ? key : never]?: TElement[key]
 };
 
 export type PropsLifecycle<TElement extends HTMLElement> = {
@@ -116,10 +113,10 @@ export type PropsLifecycle<TElement extends HTMLElement> = {
 };
 
 export type PropsAll<TElement extends HTMLElement> =
-  | PropsHTMLElement<TElement>
-  | PropsLifecycle<TElement>
+  PropsHTMLElement<TElement> &
+  (PropsLifecycle<TElement>
   | Props<TElement>
-  | ChildDom;
+  | ChildDom);
 
 export type BindElementFunc = (input?: {
   element: HTMLElement;

--- a/bau/examples/bau-ts-test/src/main.ts
+++ b/bau/examples/bau-ts-test/src/main.ts
@@ -469,8 +469,8 @@ const TestDerived = () => {
     input({
       placeholder: "Enter username",
       value: inputState,
-      oninput: ({ target }) => target instanceof HTMLInputElement &&
-        (inputState.val = target.value),
+      oninput: ({ target }) => 
+        inputState.val = (target as HTMLInputElement).value
     }),
     button(
       {
@@ -495,8 +495,8 @@ const TestDerivedSideEffect = () => {
     input({
       placeholder: "Enter username",
       value: inputState,
-      oninput: ({target}) => target instanceof HTMLInputElement &&
-        (inputState.val = target.value),
+      oninput: ({target}) =>
+        inputState.val = (target as HTMLInputElement).value,
     })
   )
 };
@@ -574,8 +574,8 @@ const TestInputOninput = () => {
     input({
       placeholder: "Enter username",
       value: inputState,
-      oninput: ({ target }) => target instanceof HTMLInputElement &&
-        (inputState.val = target.value),
+      oninput: ({ target }) =>
+        inputState.val = (target as HTMLInputElement).value
     }),
     button(
       {
@@ -597,8 +597,8 @@ const TestInputSearch = () => {
       type: "search",
       placeholder: "Search...",
       value: inputState,
-      oninput: ({ target }) => target instanceof HTMLInputElement &&
-        (inputState.val = target.value),
+      oninput: ({ target }) =>
+        inputState.val = (target as HTMLInputElement).value
     }),
     button(
       {
@@ -642,8 +642,8 @@ const TestEventHandlingKeyUp = () => {
       type: "search",
       size: 25,
       onkeyup: ({ target, key }: KeyboardEvent) => {
-        if (key == "Enter" && target instanceof HTMLInputElement) {
-          alert(target.value);
+        if (key == "Enter") {
+          alert((target as HTMLInputElement).value);
         }
       },
       placeholder: "Enter text, press Enter",
@@ -659,8 +659,8 @@ const TestInputCheckboxOninput = () => {
     input({
       type: "checkbox",
       checked: checkedState,
-      oninput: ({ target }) => target instanceof HTMLInputElement &&
-        (checkedState.val = target.checked),
+      oninput: ({ target }) =>
+        checkedState.val = (target as HTMLInputElement).checked
     }),
     div("Is checked: ", () => (checkedState.val ? "Checked" : "Not Checked"))
   );
@@ -668,8 +668,8 @@ const TestInputCheckboxOninput = () => {
 
 const TestInputRadio = () => {
   const checkedState = bau.state("one");
-  const oninput = ({ target }: Event) => target instanceof HTMLElement &&
-    (checkedState.val = target.id);
+  const oninput = ({ target }: Event) =>
+    checkedState.val = (target as HTMLElement).id
 
   return article(
     h1("Input radio"),
@@ -697,8 +697,8 @@ const TestInputRadio = () => {
 const TestSelect = () => {
   const selectState = bau.state("volvo");
 
-  const onchange = ({ target }: Event) => target instanceof HTMLSelectElement &&
-    (selectState.val = target.value);
+  const onchange = ({ target }: Event) =>
+    selectState.val = (target as HTMLSelectElement).value;
 
   return article(
     h1("Select"),

--- a/bau/examples/bau-ts-test/src/main.ts
+++ b/bau/examples/bau-ts-test/src/main.ts
@@ -469,7 +469,7 @@ const TestDerived = () => {
     input({
       placeholder: "Enter username",
       value: inputState,
-      oninput: ({ target }: { target: HTMLInputElement }) =>
+      oninput: ({ target }) => target instanceof HTMLInputElement &&
         (inputState.val = target.value),
     }),
     button(
@@ -495,10 +495,10 @@ const TestDerivedSideEffect = () => {
     input({
       placeholder: "Enter username",
       value: inputState,
-      oninput: ({ target }: { target: HTMLInputElement }) =>
+      oninput: ({target}) => target instanceof HTMLInputElement &&
         (inputState.val = target.value),
     })
-  );
+  )
 };
 
 const TestDeriveText = () => {
@@ -574,7 +574,7 @@ const TestInputOninput = () => {
     input({
       placeholder: "Enter username",
       value: inputState,
-      oninput: ({ target }: { target: HTMLInputElement }) =>
+      oninput: ({ target }) => target instanceof HTMLInputElement &&
         (inputState.val = target.value),
     }),
     button(
@@ -597,7 +597,7 @@ const TestInputSearch = () => {
       type: "search",
       placeholder: "Search...",
       value: inputState,
-      oninput: ({ target }: { target: HTMLInputElement }) =>
+      oninput: ({ target }) => target instanceof HTMLInputElement &&
         (inputState.val = target.value),
     }),
     button(
@@ -641,8 +641,8 @@ const TestEventHandlingKeyUp = () => {
     input({
       type: "search",
       size: 25,
-      onkeyup: ({ target, key }: { key: string; target: HTMLInputElement }) => {
-        if (key == "Enter") {
+      onkeyup: ({ target, key }: KeyboardEvent) => {
+        if (key == "Enter" && target instanceof HTMLInputElement) {
           alert(target.value);
         }
       },
@@ -659,7 +659,7 @@ const TestInputCheckboxOninput = () => {
     input({
       type: "checkbox",
       checked: checkedState,
-      oninput: ({ target }: { target: HTMLInputElement }) =>
+      oninput: ({ target }) => target instanceof HTMLInputElement &&
         (checkedState.val = target.checked),
     }),
     div("Is checked: ", () => (checkedState.val ? "Checked" : "Not Checked"))
@@ -668,7 +668,7 @@ const TestInputCheckboxOninput = () => {
 
 const TestInputRadio = () => {
   const checkedState = bau.state("one");
-  const oninput = ({ target }: { target: HTMLInputElement }) =>
+  const oninput = ({ target }: Event) => target instanceof HTMLElement &&
     (checkedState.val = target.id);
 
   return article(
@@ -697,7 +697,7 @@ const TestInputRadio = () => {
 const TestSelect = () => {
   const selectState = bau.state("volvo");
 
-  const onchange = ({ target }: { target: HTMLSelectElement }) =>
+  const onchange = ({ target }: Event) => target instanceof HTMLSelectElement &&
     (selectState.val = target.value);
 
   return article(


### PR DESCRIPTION
Now 

```js
button({
  onclick: (e) => {}
});
```

will have the correct type for `e` (and not `any`).

I removed the other types in the `PropsHTMLElement` union since they are duplicated in `Props`.