### PR TITLE
Fix type errors bau.d.ts

### DIFF
--- a/bau/bau.d.ts
+++ b/bau/bau.d.ts
@@ -32,7 +32,7 @@ export interface BindInput {
   readonly deps: Deps;
   readonly render: (input: {
     element: HTMLElement;
-    readonly renderItem: RenderItem;
+    readonly renderItem: typeof RenderItem;
     readonly oldValues: any[];
   }) => (...args: readonly any[]) => HTMLElement | StatePrimitive;
   readonly renderItem?: typeof RenderItem;
@@ -135,7 +135,7 @@ export type TagFunc<Result extends HTMLElement> = (
   ...rest: readonly ChildDom[]
 ) => Result;
 
-type Tags = Readonly<Record<string, TagFunc<Element>>> & {
+type Tags = Readonly<Record<string, TagFunc<HTMLElement>>> & {
   [K in keyof HTMLElementTagNameMap]: TagFunc<HTMLElementTagNameMap[K]>;
 };
 


### PR DESCRIPTION
'RenderItem' refers to a value, but is being used as a type here. Did you mean 'typeof RenderItem'?

Type 'Element' does not satisfy the constraint 'HTMLElement'.
  Type 'Element' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, dir, and 126 more.
